### PR TITLE
Update elm-webpack-loader and enable forceWatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ This is possible because of [react-elm-components](https://github.com/evancz/rea
 
 You can write any separate component in Elm and then wrap it into React component which can be integrated with whole application. Elm code should be placed in `src/elm` and every component whould have main file in this directory and all files related to this component in directory with the same name. React wrapper file should have the same name as Elm component and `flow` should be disabled for this file.
 
-Right now Webpack and Elm integration is not ideal. Webpack is only watching for files in `src/elm` and only this files can trigger recompile. We are trying to figure out solution to this problem for better Elm experience.
-
 ```elm
 -- src/elm/About.elm
 

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -3,9 +3,7 @@ var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 var InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
-var WatchMissingNodeModulesPlugin = require(
-  'react-dev-utils/WatchMissingNodeModulesPlugin'
-);
+var WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 var getClientEnvironment = require('./env');
 var paths = require('./paths');
 
@@ -129,7 +127,7 @@ module.exports = {
       {
         test: /\.elm$/,
         exclude: [/elm-stuff/, /node_modules/],
-        loader: 'elm-webpack'
+        loader: 'elm-webpack?forceWatch=true'
       },
       // "postcss" loader applies autoprefixer to our CSS.
       // "css" loader resolves paths in CSS and adds assets as dependencies.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "css-loader": "0.26.1",
     "detect-port": "1.0.1",
     "dotenv": "2.0.0",
-    "elm-webpack-loader": "4.1.1",
+    "elm-webpack-loader": "^4.3.0",
     "eslint": "3.8.1",
     "eslint-config-react-app": "^0.5.1",
     "eslint-loader": "1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1759,13 +1759,13 @@ electron-to-chromium@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.2.3.tgz#4b4d04d237c301f72e2d15c2137b2b79f9f5ab76"
 
-elm-webpack-loader@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/elm-webpack-loader/-/elm-webpack-loader-4.1.1.tgz#6c8b5f88e36c6885955e7de0e7df8a3c7aab1871"
+elm-webpack-loader@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/elm-webpack-loader/-/elm-webpack-loader-4.3.0.tgz#796d391794b44aac6b865d9a5d045b597e486117"
   dependencies:
     elm "^0.18.0"
     glob "^7.1.1"
-    loader-utils "^0.2.11"
+    loader-utils "^1.0.2"
     node-elm-compiler "^4.2.1"
     yargs "^6.5.0"
 
@@ -3316,6 +3316,14 @@ loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
+
+loader-utils@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
 
 lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.4"


### PR DESCRIPTION
Fixes: #3

Thanks to `elm-webpack-loader` 4.3 now we have first class Elm support with reloading on `.elm` files change!!!